### PR TITLE
Handle QUERY_ALL_PACKAGES permission workflow

### DIFF
--- a/app/src/main/kotlin/com/absinthe/libchecker/features/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/features/home/HomeViewModel.kt
@@ -88,6 +88,7 @@ class HomeViewModel : ViewModel() {
   var controller: IListController? = null
   var appListStatus: Int = STATUS_NOT_START
   var workerBinder: IWorkerService? = null
+  var shouldCheckQueryAllPackagesPermissionOnResume: Boolean = false
 
   // Simple menu state management
   var isSearchMenuExpanded: Boolean = false

--- a/app/src/main/kotlin/com/absinthe/libchecker/features/home/ui/MainActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/features/home/ui/MainActivity.kt
@@ -1,8 +1,10 @@
 package com.absinthe.libchecker.features.home.ui
 
+import android.Manifest
 import android.content.ComponentName
 import android.content.Intent
 import android.content.ServiceConnection
+import android.content.pm.PackageManager
 import android.os.Bundle
 import android.os.IBinder
 import android.view.Menu
@@ -10,6 +12,7 @@ import android.view.View
 import androidx.activity.viewModels
 import androidx.appcompat.widget.SearchView
 import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.core.content.ContextCompat
 import androidx.core.view.MenuProvider
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
@@ -306,6 +309,21 @@ class MainActivity :
       enabledState = { !isKeyboardShowing() && binding.toolbar.hasExpandedActionView() },
       handler = { binding.toolbar.collapseActionView() }
     )
+  }
+
+  override fun onResume() {
+    super.onResume()
+    if (appViewModel.shouldCheckQueryAllPackagesPermissionOnResume) {
+      val granted =
+        ContextCompat.checkSelfPermission(
+          this,
+          Manifest.permission.QUERY_ALL_PACKAGES
+        ) == PackageManager.PERMISSION_GRANTED
+      if (granted) {
+        appViewModel.shouldCheckQueryAllPackagesPermissionOnResume = false
+        appViewModel.initItems()
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary
- request the QUERY_ALL_PACKAGES permission when the rejection view is tapped
- track when the permission is missing so the app list can be reloaded once it is granted
- trigger app list initialization after the user enables the permission

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6c99dbeb0832ca37cce70a1f4448a